### PR TITLE
Add course formats links and "for individuals whom slides"

### DIFF
--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -15,16 +15,27 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1B4LwuvgA6aUopOHE
 
 One of the key cancer informatics challenges is dealing with and managing the explosion of large data from multiple sources that are often too large to work with on typical personal computers. This course is designed to help researchers and investigators to understand the basics of computing and to familiarize them with various computing  options to ultimately help guide their decisions on the topic.
 
-## Target Audience 
+## Target Audience
 
 This course is intended for researchers (including postdocs and students) with limited to intermediate experience with informatics research. The conceptual material will also be useful for those in management roles who are collecting data and using informatics pipelines.
 
-## Curriculum 
 
-The course will cover the key underlying principles and concepts in computing. It will cover concrete discussions of the differences between cloud and local computing. The course will highlight a number of computing options and etiquette for using shared resources. 
+```{r, fig.align='center', echo = FALSE, fig.alt= "For individuals whom: Have no formal training in informatics. Are relatively new to informatics. Want to learn the basics of computers and shared computing resources. Want guidance for choosing computing options
+", out.width= "100%"}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1B4LwuvgA6aUopOHEAbES1Agjy7Ex2IpVAoUIoBFbsq0/edit#slide=id.g11db82d2864_1_65")
+```
+
+## Topics covered:
+
+```{r, fig.align='center', echo = FALSE, fig.alt= "Concepts discussed in the Computing for Cancer Informatics course: How computer hardware and software work. Computing resources designed for research Data sizes and computational capacity. Guidance about computing resource decisions. How shared computing resources work. Etiquette for shared computing resources.", out.width= "100%"}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1B4LwuvgA6aUopOHEAbES1Agjy7Ex2IpVAoUIoBFbsq0/edit#slide=id.g11db82d2864_1_81")
+```
+
+## Curriculum
+
+The course will cover the key underlying principles and concepts in computing. It will cover concrete discussions of the differences between cloud and local computing. The course will highlight a number of computing options and etiquette for using shared resources.
 
 
 ```{r, fig.align='center', echo = FALSE, fig.alt= "Overall Course Learning Objectives. This course will demonstrate how to: 1.Recognize various data management systems especially for cancer research related data, 2.Compare and make informed decisions about computation platforms (including economic considerations),3.Implement best practices for data security and privacy, 4. Share data safely and securely in a variety of contexts,5.Handle IRB and data access requests,6.Apply ethical consideration in data management workflows", out.width= "100%"}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1B4LwuvgA6aUopOHEAbES1Agjy7Ex2IpVAoUIoBFbsq0/edit#slide=id.gf5f8818810_1_5")
 ```
-

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,4 +1,4 @@
---- 
+---
 title: "Computing for Cancer Informatics"
 date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
@@ -21,3 +21,13 @@ knitr::write_bib(c(
 # About This Course {-}
 
 This course is part of a series of courses for the [Informatics Technology for Cancer Research (ITCR)](https://itcr.cancer.gov/) called the Informatics Technology for Cancer Research Education Resource. This material was created by the ITCR Training Network (ITN)  which is a collaborative effort of researchers around the United States to support cancer informatics and data science training through resources, technology, and events. This initiative is funded by the following grant:  [National Cancer Institute (NCI)](https://www.cancer.gov/)  UE5 CA254170. Our courses feature tools developed by ITCR Investigators and make it easier for principal investigators, scientists, and analysts to integrate cancer informatics into their workflows. Please see our website at [www.itcrtraining.org](www.itcrtraining.org) for more information. Except where otherwise indicated, the contents of this course are available for use under the Creative Commons Attribution 4.0 license. You are free to adapt and share the work, but you must give appropriate credit, provide a link to the license, and indicate if changes were made. Sample attribution: Data Management for Cancer Research by Johns Hopkins Data Science Lab (CC-BY 4.0). You can download the illustrations by clicking [here](https://docs.google.com/presentation/d/1B4LwuvgA6aUopOHEAbES1Agjy7Ex2IpVAoUIoBFbsq0/edit?usp=sharing).
+
+
+## Available course formats
+
+This course is available in multiple formats which allows you to take it in the way that best suites your needs. You can take it for certificate which can be for free or fee.
+
+- The material for this course can be viewed without login requirement on this [Bookdown website](https://jhudatascience.org/Computing_for_Cancer_Informatics/). This format might be most appropriate for you if you rely on screen-reader technology.
+- This course can be taken for [free certification through Leanpub](https://leanpub.com/universities/courses/jhu/computing-for-cancer-informatics).
+- This course can be taken on [Coursera for certification here](https://www.coursera.org/learn/computing-for-cancer-informatics) (but it is not available for free on Coursera).
+- Our courses are open source, you can find the [source material for this course on GitHub](https://github.com/jhudsl/Computing_for_Cancer_Informatics).

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -17,12 +17,14 @@ bioinformatics
 Biostrings
 BIRN
 Blavatnik
+Bookdown
 Bukner
 cBIBOP
 CDUs
 citable
 CGC
 Collaboratory
+Coursera
 CRC
 cybercriminal
 cybercriminals
@@ -83,6 +85,7 @@ Keychain
 Klarman
 Knowledgebase
 Kubernettes
+Leanpub
 ligand
 ottr
 macOS
@@ -105,6 +108,7 @@ n2c2
 OHIF
 omics
 OpenBEL
+ottrpal
 PCAWG
 PKCS
 PoLP


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

These adds are a part of a series across all current ITCR courses are two fold: 

1) Add course format links so people are aware of the other ways to take the course no matter where they land. 
2) Make it clear up front whom the course is for and what topics are covered by adding in our standard slide cards. 